### PR TITLE
request with params for get_liquidation()

### DIFF
--- a/okex-python-sdk-api/example.py
+++ b/okex-python-sdk-api/example.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     # result = futureAPI.get_estimated_price('BTC-USD-181019')
     # result = futureAPI.get_holds('BTC-USD-181019')
     # result = futureAPI.get_limit('BTC-USD-181019')
-    # result = futureAPI.get_liquidation('BTC-USD-181019', 0)
+    # result = futureAPI.get_liquidation('BTC-USD-181019', '0')
     # result = futureAPI.get_holds_amount('BCH-USD-181019')
     # result = futureAPI.get_mark_price('BCH-USD-181019')
 

--- a/okex-python-sdk-api/okex/futures_api.py
+++ b/okex-python-sdk-api/okex/futures_api.py
@@ -177,7 +177,7 @@ class FutureAPI(Client):
             params['to'] = to
         if limit:
             params['limit'] = limit
-        return self._request_without_params(GET, FUTURE_LIQUIDATION + str(instrument_id) + '/liquidation')
+        return self._request_with_params(GET, FUTURE_LIQUIDATION + str(instrument_id) + '/liquidation', params)
 
     # query holds amount
     def get_holds_amount(self, instrument_id):


### PR DESCRIPTION
According to the [API doc](https://www.okex.com/docs/zh/#futures-huo-qu-bao-cang-dan ) of OKEx, there is a required param named `status` of `get_liquidation()`.

So, we should call `future._request_with_params()` instead of `future. _request_without_params()` here.

At the same time, I replaced the example of `get_liquidation()` cause type of `status` is `string` instead of `int`.

@typa01 @lingtingfu PTAL